### PR TITLE
CBP - Broker Wallet Wizard refactor -

### DIFF
--- a/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-broker-bitdubai/src/main/java/com/bitdubai/reference_wallet/crypto_broker_wallet/fragments/wizard_pages/WizardPageOtherSettingsFragment.java
+++ b/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-broker-bitdubai/src/main/java/com/bitdubai/reference_wallet/crypto_broker_wallet/fragments/wizard_pages/WizardPageOtherSettingsFragment.java
@@ -62,6 +62,10 @@ import com.bitdubai.reference_wallet.crypto_broker_wallet.session.CryptoBrokerWa
          walletManager = moduleManager.getCryptoBrokerWallet(appSession.getAppPublicKey());
          errorManager = appSession.getErrorManager();
 
+       //Delete potential previous configurations made by this wizard page
+       //So that they can be reconfigured cleanly
+       walletManager.clearWalletSetting(appSession.getAppPublicKey());
+
        } catch (FermatException ex) {
          Log.e(TAG, ex.getMessage(), ex);
        }

--- a/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-broker-bitdubai/src/main/java/com/bitdubai/reference_wallet/crypto_broker_wallet/fragments/wizard_pages/WizardPageSetMerchandisesFragment.java
+++ b/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-broker-bitdubai/src/main/java/com/bitdubai/reference_wallet/crypto_broker_wallet/fragments/wizard_pages/WizardPageSetMerchandisesFragment.java
@@ -88,7 +88,7 @@ public class WizardPageSetMerchandisesFragment extends AbstractFermatFragment<Cr
             walletManager = moduleManager.getCryptoBrokerWallet(appSession.getAppPublicKey());
             errorManager = appSession.getErrorManager();
 
-            // Verify if wallet configured, if it is, show this fragment, else show the home fragment (the second start fragment)
+            // Verify if wallet has been configured, if true show this fragment, else show the home fragment (the second start fragment)
             boolean walletConfigured;
             try {
                 walletConfigured = walletManager.isWalletConfigured(appSession.getAppPublicKey());
@@ -99,6 +99,15 @@ public class WizardPageSetMerchandisesFragment extends AbstractFermatFragment<Cr
 
             if (walletConfigured) {
                 getRuntimeManager().changeStartActivity(1);
+
+                //TODO: No deberia ser necesario esta linea una vez que el changeStartActivity() funcione...
+                changeActivity(Activities.CBP_CRYPTO_BROKER_WALLET_HOME, appSession.getAppPublicKey());
+                return;
+            } else {
+                //Delete potential previous configurations made by this wizard page
+                //So that they can be reconfigured cleanly
+                walletManager.clearAssociatedIdentities(appSession.getAppPublicKey());
+                walletManager.clearAssociatedWalletSettings(appSession.getAppPublicKey());
             }
 
             //Obtain walletSettings or create new wallet settings if first time opening wallet
@@ -113,6 +122,8 @@ public class WizardPageSetMerchandisesFragment extends AbstractFermatFragment<Cr
                 walletSettings = new CryptoBrokerWalletPreferenceSettings();
                 walletSettings.setIsPresentationHelpEnabled(true);
                 moduleManager.getSettingsManager().persistSettings(appSession.getAppPublicKey(), walletSettings);
+            } else {
+                selectedIdentity = walletManager.getListOfIdentities().get(0);
             }
 
         } catch (Exception ex) {

--- a/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-broker-bitdubai/src/main/java/com/bitdubai/reference_wallet/crypto_broker_wallet/fragments/wizard_pages/WizardPageSetProvidersFragment.java
+++ b/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-broker-bitdubai/src/main/java/com/bitdubai/reference_wallet/crypto_broker_wallet/fragments/wizard_pages/WizardPageSetProvidersFragment.java
@@ -83,6 +83,11 @@ public class WizardPageSetProvidersFragment extends AbstractFermatFragment
             walletManager = moduleManager.getCryptoBrokerWallet(appSession.getAppPublicKey());
             errorManager = appSession.getErrorManager();
 
+            //Delete potential previous configurations made by this wizard page
+            //So that they can be reconfigured cleanly
+            walletManager.clearCryptoBrokerWalletProviderSetting(appSession.getAppPublicKey());
+
+
         } catch (Exception ex) {
             Log.e(TAG, ex.getMessage(), ex);
             if (errorManager != null)

--- a/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/actor/crypto_broker/exceptions/CantClearBrokerIdentityWalletRelationshipException.java
+++ b/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/actor/crypto_broker/exceptions/CantClearBrokerIdentityWalletRelationshipException.java
@@ -1,0 +1,26 @@
+package com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions;
+
+import com.bitdubai.fermat_api.FermatException;
+
+/**
+ * Created by Alejandro Bicelis on 06/03/2016.
+ */
+
+public class CantClearBrokerIdentityWalletRelationshipException extends FermatException {
+
+    public static final String DEFAULT_MESSAGE = "CAN'T CLEAR NEW BROKER IDENTITY WALLET RELATIONSHIP";
+
+    /**
+     * This is the constructor that every inherited FermatException must implement
+     *
+     * @param message        the short description of the why this exception happened, there is a public static constant called DEFAULT_MESSAGE that can be used here
+     * @param cause          the exception that triggered the throwing of the current exception, if there are no other exceptions to be declared here, the cause should be null
+     * @param context        a String that provides the values of the variables that could have affected the exception
+     * @param possibleReason an explicative reason of why we believe this exception was most likely thrown
+     */
+
+    public CantClearBrokerIdentityWalletRelationshipException(String message, Exception cause, String context, String possibleReason) {
+        super(message, cause, context, possibleReason);
+    }
+
+}

--- a/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/actor/crypto_broker/interfaces/CryptoBrokerActorManager.java
+++ b/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/actor/crypto_broker/interfaces/CryptoBrokerActorManager.java
@@ -2,6 +2,7 @@ package com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.interfaces;
 
 import com.bitdubai.fermat_api.layer.all_definition.common.system.interfaces.FermatManager;
 import com.bitdubai.fermat_cbp_api.all_definition.identity.ActorIdentity;
+import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantClearBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantCreateNewBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantGetListBrokerIdentityWalletRelationshipException;
 
@@ -22,6 +23,15 @@ public interface CryptoBrokerActorManager extends FermatManager {
      * @throws CantCreateNewBrokerIdentityWalletRelationshipException
      */
     BrokerIdentityWalletRelationship createNewBrokerIdentityWalletRelationship(ActorIdentity identity, String walletPublicKey) throws CantCreateNewBrokerIdentityWalletRelationshipException;
+
+    /**
+     *
+     * @param walletPublicKey
+     * @return
+     * @throws CantCreateNewBrokerIdentityWalletRelationshipException
+     */
+    void clearBrokerIdentityWalletRelationship(String walletPublicKey) throws CantClearBrokerIdentityWalletRelationshipException;
+
 
     /**
      *

--- a/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/business_transaction/common/mocks/CryptoBrokerWalletSettingMock.java
+++ b/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/business_transaction/common/mocks/CryptoBrokerWalletSettingMock.java
@@ -1,6 +1,7 @@
 package com.bitdubai.fermat_cbp_api.layer.business_transaction.common.mocks;
 
 import com.bitdubai.fermat_cbp_api.all_definition.enums.MoneyType;
+import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantClearCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantSaveCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.interfaces.setting.CryptoBrokerWalletAssociatedSetting;
@@ -21,12 +22,22 @@ public class CryptoBrokerWalletSettingMock implements CryptoBrokerWalletSetting 
     }
 
     @Override
+    public void clearCryptoBrokerWalletSpreadSetting() throws CantClearCryptoBrokerWalletSettingException {
+
+    }
+
+    @Override
     public CryptoBrokerWalletSettingSpread getCryptoBrokerWalletSpreadSetting() throws CantGetCryptoBrokerWalletSettingException {
         return null;
     }
 
     @Override
     public void saveCryptoBrokerWalletAssociatedSetting(CryptoBrokerWalletAssociatedSetting cryptoBrokerWalletAssociatedSetting) throws CantSaveCryptoBrokerWalletSettingException {
+
+    }
+
+    @Override
+    public void clearCryptoBrokerWalletAssociatedSetting() throws CantClearCryptoBrokerWalletSettingException {
 
     }
 
@@ -42,6 +53,11 @@ public class CryptoBrokerWalletSettingMock implements CryptoBrokerWalletSetting 
 
     @Override
     public void saveCryptoBrokerWalletProviderSetting(CryptoBrokerWalletProviderSetting cryptoBrokerWalletProviderSetting) throws CantSaveCryptoBrokerWalletSettingException {
+
+    }
+
+    @Override
+    public void clearCryptoBrokerWalletProviderSetting() throws CantClearCryptoBrokerWalletSettingException {
 
     }
 

--- a/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/wallet/crypto_broker/exceptions/CantClearCryptoBrokerWalletSettingException.java
+++ b/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/wallet/crypto_broker/exceptions/CantClearCryptoBrokerWalletSettingException.java
@@ -1,0 +1,23 @@
+package com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions;
+
+import com.bitdubai.fermat_api.FermatException;
+
+/**
+ * Created by Alejandro Bicelis on 06/03/2016
+ */
+public class CantClearCryptoBrokerWalletSettingException extends FermatException {
+
+    public static final String DEFAULT_MESSAGE = "CANT CLEAR CRYPTO BROKER WALLET SETTING";
+
+    /**
+     * This is the constructor that every inherited FermatException must implement
+     *
+     * @param message        the short description of the why this exception happened, there is a public static constant called DEFAULT_MESSAGE that can be used here
+     * @param cause          the exception that triggered the throwing of the current exception, if there are no other exceptions to be declared here, the cause should be null
+     * @param context        a String that provides the values of the variables that could have affected the exception
+     * @param possibleReason an explicative reason of why we believe this exception was most likely thrown
+     */
+    public CantClearCryptoBrokerWalletSettingException(String message, Exception cause, String context, String possibleReason) {
+        super(message, cause, context, possibleReason);
+    }
+}

--- a/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/wallet/crypto_broker/interfaces/setting/CryptoBrokerWalletSetting.java
+++ b/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/wallet/crypto_broker/interfaces/setting/CryptoBrokerWalletSetting.java
@@ -1,5 +1,6 @@
 package com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.interfaces.setting;
 
+import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantClearCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantSaveCryptoBrokerWalletSettingException;
 
@@ -18,6 +19,12 @@ public interface CryptoBrokerWalletSetting {
      */
     void saveCryptoBrokerWalletSpreadSetting(CryptoBrokerWalletSettingSpread cryptoBrokerWalletSettingSpread) throws CantSaveCryptoBrokerWalletSettingException;
     /**
+     * This method clears the instance CryptoBrokerWalletSettingSpread
+     * @return
+     * @exception CantSaveCryptoBrokerWalletSettingException
+     */
+    void clearCryptoBrokerWalletSpreadSetting() throws CantClearCryptoBrokerWalletSettingException;
+    /**
      * This method load the instance saveCryptoBrokerWalletSpreadSetting
      * @param
      * @return CryptoBrokerWalletSettingSpread
@@ -32,6 +39,14 @@ public interface CryptoBrokerWalletSetting {
      * @exception CantSaveCryptoBrokerWalletSettingException
      */
     void saveCryptoBrokerWalletAssociatedSetting(CryptoBrokerWalletAssociatedSetting cryptoBrokerWalletAssociatedSetting) throws CantSaveCryptoBrokerWalletSettingException;
+
+    /**
+     * This method clears the instance CryptoBrokerWalletAssociatedSetting
+     * @return
+     * @exception CantSaveCryptoBrokerWalletSettingException
+     */
+    void clearCryptoBrokerWalletAssociatedSetting() throws CantClearCryptoBrokerWalletSettingException;
+
     /**
      * This method load the list CryptoBrokerWalletProviderSetting
      * @param
@@ -47,6 +62,13 @@ public interface CryptoBrokerWalletSetting {
      * @exception CantSaveCryptoBrokerWalletSettingException
      */
     void saveCryptoBrokerWalletProviderSetting(CryptoBrokerWalletProviderSetting cryptoBrokerWalletProviderSetting) throws CantSaveCryptoBrokerWalletSettingException;
+
+    /**
+     * This method clears the instance CryptoBrokerWalletProviderSetting
+     * @return
+     * @exception CantSaveCryptoBrokerWalletSettingException
+     */
+    void clearCryptoBrokerWalletProviderSetting() throws CantClearCryptoBrokerWalletSettingException;
     /**
      * This method load the list CryptoBrokerWalletProviderSetting
      * @param

--- a/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/wallet_module/crypto_broker/interfaces/CryptoBrokerWalletManager.java
+++ b/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/wallet_module/crypto_broker/interfaces/CryptoBrokerWalletManager.java
@@ -19,6 +19,7 @@ import com.bitdubai.fermat_cbp_api.all_definition.enums.OriginTransaction;
 import com.bitdubai.fermat_cbp_api.all_definition.identity.ActorIdentity;
 import com.bitdubai.fermat_cbp_api.all_definition.negotiation.NegotiationBankAccount;
 import com.bitdubai.fermat_cbp_api.all_definition.negotiation.NegotiationLocations;
+import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantClearBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantCreateNewBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantGetListBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.business_transaction.common.exceptions.CantAckPaymentException;
@@ -48,6 +49,7 @@ import com.bitdubai.fermat_cbp_api.layer.stock_transactions.cash_money_destock.e
 import com.bitdubai.fermat_cbp_api.layer.stock_transactions.cash_money_restock.exceptions.CantCreateCashMoneyRestockException;
 import com.bitdubai.fermat_cbp_api.layer.stock_transactions.crypto_money_destock.exceptions.CantCreateCryptoMoneyDestockException;
 import com.bitdubai.fermat_cbp_api.layer.stock_transactions.crypto_money_restock.exceptions.CantCreateCryptoMoneyRestockException;
+import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantClearCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetAvailableBalanceCryptoBrokerWalletException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetCryptoBrokerMarketRateException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetCryptoBrokerQuoteException;
@@ -106,6 +108,13 @@ public interface CryptoBrokerWalletManager extends WalletManager {
      * @param brokerPublicKey the Public Key of the Crypto Broker who is going to be associated with this wallet
      */
     boolean associateIdentity(ActorIdentity brokerPublicKey, String brokerWalletPublicKey) throws CantCreateNewBrokerIdentityWalletRelationshipException;
+
+    /**
+     * Clear any associated identities to this wallet
+     *
+     * @param brokerWalletPublicKey the Public Key of the wallet to be cleared of its identity
+     */
+    void clearAssociatedIdentities(String brokerWalletPublicKey) throws CantClearBrokerIdentityWalletRelationshipException;
 
     Quote getQuote(Currency merchandise, Currency currencyPayment, String brokerWalletPublicKey) throws CantGetCryptoBrokerQuoteException;
 
@@ -196,7 +205,11 @@ public interface CryptoBrokerWalletManager extends WalletManager {
 
     void saveWalletSetting(CryptoBrokerWalletSettingSpread cryptoBrokerWalletSettingSpread, String publicKeyWalletCryptoBrokerInstall) throws CantSaveCryptoBrokerWalletSettingException, CryptoBrokerWalletNotFoundException, CantGetCryptoBrokerWalletSettingException;
 
+    void clearWalletSetting(String publicKeyWalletCryptoBrokerInstall) throws CantClearCryptoBrokerWalletSettingException, CryptoBrokerWalletNotFoundException, CantGetCryptoBrokerWalletSettingException;
+
     void saveWalletSettingAssociated(CryptoBrokerWalletAssociatedSetting cryptoBrokerWalletAssociatedSetting, String publicKeyWalletCryptoBrokerInstall) throws CantGetCryptoBrokerWalletSettingException, CryptoBrokerWalletNotFoundException, CantSaveCryptoBrokerWalletSettingException;
+
+    void clearAssociatedWalletSettings(String publicKeyWalletCryptoBrokerInstall) throws CryptoBrokerWalletNotFoundException, CantGetCryptoBrokerWalletSettingException, CantClearCryptoBrokerWalletSettingException;
 
     boolean isWalletConfigured(String publicKeyWalletCryptoBrokerInstall) throws CryptoBrokerWalletNotFoundException, CantGetCryptoBrokerWalletSettingException;
 
@@ -491,6 +504,14 @@ public interface CryptoBrokerWalletManager extends WalletManager {
      * @throws CantSaveCryptoBrokerWalletSettingException
      */
     void saveCryptoBrokerWalletProviderSetting(CryptoBrokerWalletProviderSetting cryptoBrokerWalletProviderSetting, String walletPublicKey) throws CantSaveCryptoBrokerWalletSettingException, CryptoBrokerWalletNotFoundException, CantGetCryptoBrokerWalletSettingException;
+
+    /**
+     * This method clears the instance CryptoBrokerWalletProviderSetting
+     *
+     * @return
+     * @throws CantClearCryptoBrokerWalletSettingException
+     */
+    void clearCryptoBrokerWalletProviderSetting(String walletPublicKey) throws CantClearCryptoBrokerWalletSettingException, CryptoBrokerWalletNotFoundException, CantGetCryptoBrokerWalletSettingException;
 
     /**
      * @param bankAccount

--- a/CBP/plugin/actor/fermat-cbp-plugin-actor-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/actor/crypto_broker/developer/bitdubai/version_1/database/CryptoBrokerActorDao.java
+++ b/CBP/plugin/actor/fermat-cbp-plugin-actor-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/actor/crypto_broker/developer/bitdubai/version_1/database/CryptoBrokerActorDao.java
@@ -3,15 +3,18 @@ package com.bitdubai.fermat_cbp_plugin.layer.actor.crypto_broker.developer.bitdu
 import com.bitdubai.fermat_api.layer.all_definition.exceptions.InvalidParameterException;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFilterType;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseRecord;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTableRecord;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.PluginDatabaseSystem;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.CantCreateDatabaseException;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.CantDeleteRecordException;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.CantInsertRecordException;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.CantLoadTableToMemoryException;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.CantOpenDatabaseException;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.DatabaseNotFoundException;
 import com.bitdubai.fermat_cbp_api.all_definition.identity.ActorIdentity;
+import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantClearBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantCreateNewBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantGetListBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.interfaces.BrokerIdentityWalletRelationship;
@@ -82,6 +85,24 @@ public class CryptoBrokerActorDao {
                 throw new CantCreateNewBrokerIdentityWalletRelationshipException(CantCreateNewBrokerIdentityWalletRelationshipException.DEFAULT_MESSAGE, e, "", "");
             } catch (CantGetListClauseException e) {
                 throw new CantCreateNewBrokerIdentityWalletRelationshipException(CantCreateNewBrokerIdentityWalletRelationshipException.DEFAULT_MESSAGE, e, "", "");
+            }
+        }
+
+        public void clearBrokerIdentityWalletRelationship(String walletPublicKey) throws CantClearBrokerIdentityWalletRelationshipException {
+            DatabaseTable table = this.database.getTable(CryptoBrokerActorDatabaseConstants.CRYPTO_BROKER_ACTOR_RELATIONSHIP_TABLE_NAME);
+            table.addStringFilter(CryptoBrokerActorDatabaseConstants.CRYPTO_BROKER_ACTOR_RELATIONSHIP_WALLET_COLUMN_NAME, walletPublicKey, DatabaseFilterType.EQUAL);
+
+            try {
+                table.loadToMemory();
+                List<DatabaseTableRecord> records = table.getRecords();
+
+                for(DatabaseTableRecord record : records)
+                    table.deleteRecord(record);
+
+            } catch (CantLoadTableToMemoryException e) {
+                throw new CantClearBrokerIdentityWalletRelationshipException("Cant load table to memory", e, "", "");
+            } catch (CantDeleteRecordException e) {
+                throw new CantClearBrokerIdentityWalletRelationshipException("Cant clear identities from wallet", e, "", "");
             }
         }
 

--- a/CBP/plugin/actor/fermat-cbp-plugin-actor-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/actor/crypto_broker/developer/bitdubai/version_1/structure/BrokerActorManager.java
+++ b/CBP/plugin/actor/fermat-cbp-plugin-actor-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/actor/crypto_broker/developer/bitdubai/version_1/structure/BrokerActorManager.java
@@ -6,6 +6,7 @@ import com.bitdubai.fermat_api.layer.all_definition.enums.CryptoCurrency;
 import com.bitdubai.fermat_api.layer.all_definition.enums.FiatCurrency;
 import com.bitdubai.fermat_api.layer.world.interfaces.Currency;
 import com.bitdubai.fermat_cbp_api.all_definition.identity.ActorIdentity;
+import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantClearBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantCreateNewBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantGetExtraDataActorException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantGetListBrokerIdentityWalletRelationshipException;
@@ -70,6 +71,18 @@ public class BrokerActorManager implements CryptoBrokerActorExtraDataManager {
         }
 
         @Override
+        public void clearBrokerIdentityWalletRelationship(String walletPublicKey) throws CantClearBrokerIdentityWalletRelationshipException{
+            try {
+                this.dao.clearBrokerIdentityWalletRelationship(walletPublicKey);
+            } catch (CantClearBrokerIdentityWalletRelationshipException e) {
+                this.errorManager.reportUnexpectedPluginException(this.pluginVersionReference, UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+                throw new CantClearBrokerIdentityWalletRelationshipException(e.getMessage(), e, "walletPublicKey= " + walletPublicKey, "");
+            }
+        }
+
+
+
+    @Override
         public Collection<BrokerIdentityWalletRelationship> getAllBrokerIdentityWalletRelationship() throws CantGetListBrokerIdentityWalletRelationshipException {
             try {
                 return this.dao.getAllBrokerIdentityWalletRelationship();

--- a/CBP/plugin/wallet/fermat-cbp-plugin-wallet-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/wallet/crypto_broker/developer/bitdubai/version_1/database/CryptoBrokerWalletDatabaseDao.java
+++ b/CBP/plugin/wallet/fermat-cbp-plugin-wallet-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/wallet/crypto_broker/developer/bitdubai/version_1/database/CryptoBrokerWalletDatabaseDao.java
@@ -9,10 +9,12 @@ import com.bitdubai.fermat_api.layer.all_definition.exceptions.InvalidParameterE
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFilterOrder;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseFilterType;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseRecord;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTable;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTableFilter;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTableRecord;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.DatabaseTransaction;
+import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.CantDeleteRecordException;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.CantLoadTableToMemoryException;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.CantUpdateRecordException;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.exceptions.DatabaseTransactionFailedException;
@@ -23,7 +25,9 @@ import com.bitdubai.fermat_cbp_api.all_definition.enums.BalanceType;
 import com.bitdubai.fermat_cbp_api.all_definition.enums.MoneyType;
 import com.bitdubai.fermat_cbp_api.all_definition.enums.OriginTransaction;
 import com.bitdubai.fermat_cbp_api.all_definition.enums.TransactionType;
+import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantClearBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantCalculateBalanceException;
+import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantClearCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetAvailableBalanceCryptoBrokerWalletException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetBookedBalanceCryptoBrokerWalletException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetCryptoBrokerMarketRateException;
@@ -542,7 +546,24 @@ public class CryptoBrokerWalletDatabaseDao implements DealsWithPluginFileSystem 
         }
     }
 
-    public CryptoBrokerWalletSettingSpread getCryptoBrokerWalletSpreadSetting() throws CantGetCryptoBrokerWalletSettingException {
+    public void clearCryptoBrokerWalletSpreadSetting() throws CantClearCryptoBrokerWalletSettingException {
+        DatabaseTable table = getDatabaseTable(CryptoBrokerWalletDatabaseConstants.CRYPTO_BROKER_WALLET_SPREAD_TABLE_NAME);
+        try {
+            table.loadToMemory();
+            List<DatabaseTableRecord> records = table.getRecords();
+
+            for(DatabaseTableRecord record : records)
+                table.deleteRecord(record);
+
+        } catch(CantLoadTableToMemoryException e){
+            throw new CantClearCryptoBrokerWalletSettingException("Cant load table to memory", e, "", "");
+        } catch (CantDeleteRecordException e) {
+            throw new CantClearCryptoBrokerWalletSettingException("Cant clear settings from wallet", e, "", "");
+        }
+    }
+
+
+        public CryptoBrokerWalletSettingSpread getCryptoBrokerWalletSpreadSetting() throws CantGetCryptoBrokerWalletSettingException {
         CryptoBrokerWalletSettingSpread cryptoBrokerWalletSettingSpread = null;
         try {
             for (DatabaseTableRecord record : getCryptoBrokerWalletSpreadSettingData()) {
@@ -587,6 +608,25 @@ public class CryptoBrokerWalletDatabaseDao implements DealsWithPluginFileSystem 
             throw new CantSaveCryptoBrokerWalletSettingException(CantSaveCryptoBrokerWalletSettingException.DEFAULT_MESSAGE, e, "Error trying to save the Crypto Broker Wallet Setting Associated in the database.", null);
         }
     }
+    public void clearCryptoBrokerWalletAssociatedSetting() throws CantClearCryptoBrokerWalletSettingException {
+        DatabaseTable table = getDatabaseTable(CryptoBrokerWalletDatabaseConstants.CRYPTO_BROKER_WALLET_ASSOCIATED_TABLE_NAME);
+
+        try {
+            table.loadToMemory();
+            List<DatabaseTableRecord> records = table.getRecords();
+
+            for(DatabaseTableRecord record : records)
+                table.deleteRecord(record);
+
+        } catch(CantLoadTableToMemoryException e){
+            throw new CantClearCryptoBrokerWalletSettingException("Cant load table to memory", e, "", "");
+        }  catch (CantDeleteRecordException e) {
+            throw new CantClearCryptoBrokerWalletSettingException("Cant clear settings from wallet", e, "", "");
+        }
+
+    }
+
+
 
     public List<CryptoBrokerWalletAssociatedSetting> getCryptoBrokerWalletAssociatedSettings() throws CantGetCryptoBrokerWalletSettingException {
         List<CryptoBrokerWalletAssociatedSetting> cryptoBrokerWalletAssociatedSettings = new ArrayList<>();
@@ -636,7 +676,25 @@ public class CryptoBrokerWalletDatabaseDao implements DealsWithPluginFileSystem 
         }
     }
 
-    public List<CryptoBrokerWalletProviderSetting> getCryptoBrokerWalletProviderSettings() throws CantGetCryptoBrokerWalletSettingException {
+    public void clearCryptoBrokerWalletProviderSetting() throws CantClearCryptoBrokerWalletSettingException {
+        DatabaseTable table = getDatabaseTable(CryptoBrokerWalletDatabaseConstants.CRYPTO_BROKER_WALLET_PROVIDER_TABLE_NAME);
+        try {
+            table.loadToMemory();
+            List<DatabaseTableRecord> records = table.getRecords();
+
+            for(DatabaseTableRecord record : records)
+                table.deleteRecord(record);
+
+        } catch(CantLoadTableToMemoryException e){
+            throw new CantClearCryptoBrokerWalletSettingException("Cant load table to memory", e, "", "");
+        } catch (CantDeleteRecordException e) {
+            throw new CantClearCryptoBrokerWalletSettingException("Cant clear settings from wallet", e, "", "");
+        }
+
+    }
+
+
+        public List<CryptoBrokerWalletProviderSetting> getCryptoBrokerWalletProviderSettings() throws CantGetCryptoBrokerWalletSettingException {
         List<CryptoBrokerWalletProviderSetting> cryptoBrokerWalletProviderSettings = new ArrayList<>();
         try {
             for (DatabaseTableRecord record : getCryptoBrokerWalletProviderSettingData()) {

--- a/CBP/plugin/wallet/fermat-cbp-plugin-wallet-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/wallet/crypto_broker/developer/bitdubai/version_1/structure/util/CryptoBrokerWalletSettingImpl.java
+++ b/CBP/plugin/wallet/fermat-cbp-plugin-wallet-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/wallet/crypto_broker/developer/bitdubai/version_1/structure/util/CryptoBrokerWalletSettingImpl.java
@@ -4,6 +4,7 @@ import com.bitdubai.fermat_api.FermatException;
 import com.bitdubai.fermat_api.layer.all_definition.enums.Plugins;
 import com.bitdubai.fermat_api.layer.osa_android.database_system.Database;
 import com.bitdubai.fermat_api.layer.osa_android.file_system.PluginFileSystem;
+import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantClearCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantSaveCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.interfaces.setting.CryptoBrokerWalletAssociatedSetting;
@@ -52,6 +53,14 @@ public class CryptoBrokerWalletSettingImpl implements CryptoBrokerWalletSetting 
      * {@inheritDoc}
      */
     @Override
+    public void clearCryptoBrokerWalletSpreadSetting() throws CantClearCryptoBrokerWalletSettingException {
+            cryptoBrokerWalletDatabaseDao.clearCryptoBrokerWalletSpreadSetting();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public CryptoBrokerWalletSettingSpread getCryptoBrokerWalletSpreadSetting() throws CantGetCryptoBrokerWalletSettingException {
         return cryptoBrokerWalletDatabaseDao.getCryptoBrokerWalletSpreadSetting();
     }
@@ -68,6 +77,16 @@ public class CryptoBrokerWalletSettingImpl implements CryptoBrokerWalletSetting 
      * {@inheritDoc}
      */
     @Override
+    public void clearCryptoBrokerWalletAssociatedSetting() throws CantClearCryptoBrokerWalletSettingException {
+         cryptoBrokerWalletDatabaseDao.clearCryptoBrokerWalletAssociatedSetting();
+    }
+
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<CryptoBrokerWalletAssociatedSetting> getCryptoBrokerWalletAssociatedSettings() throws CantGetCryptoBrokerWalletSettingException {
         return cryptoBrokerWalletDatabaseDao.getCryptoBrokerWalletAssociatedSettings();
     }
@@ -78,6 +97,14 @@ public class CryptoBrokerWalletSettingImpl implements CryptoBrokerWalletSetting 
     @Override
     public void saveCryptoBrokerWalletProviderSetting(CryptoBrokerWalletProviderSetting cryptoBrokerWalletProviderSetting) throws CantSaveCryptoBrokerWalletSettingException {
         cryptoBrokerWalletDatabaseDao.saveCryptoBrokerWalletProviderSetting(cryptoBrokerWalletProviderSetting);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clearCryptoBrokerWalletProviderSetting() throws CantClearCryptoBrokerWalletSettingException {
+        cryptoBrokerWalletDatabaseDao.clearCryptoBrokerWalletProviderSetting();
     }
 
     /**

--- a/CBP/plugin/wallet_module/fermat-cbp-plugin-wallet-module-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/wallet_module/crypto_broker/developer/bitdubai/version_1/structure/CryptoBrokerWalletModuleCryptoBrokerWalletManager.java
+++ b/CBP/plugin/wallet_module/fermat-cbp-plugin-wallet-module-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/wallet_module/crypto_broker/developer/bitdubai/version_1/structure/CryptoBrokerWalletModuleCryptoBrokerWalletManager.java
@@ -34,6 +34,7 @@ import com.bitdubai.fermat_cbp_api.all_definition.identity.ActorIdentity;
 import com.bitdubai.fermat_cbp_api.all_definition.negotiation.Clause;
 import com.bitdubai.fermat_cbp_api.all_definition.negotiation.NegotiationBankAccount;
 import com.bitdubai.fermat_cbp_api.all_definition.negotiation.NegotiationLocations;
+import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantClearBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantCreateNewBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.exceptions.CantGetListBrokerIdentityWalletRelationshipException;
 import com.bitdubai.fermat_cbp_api.layer.actor.crypto_broker.interfaces.BrokerIdentityWalletRelationship;
@@ -104,6 +105,7 @@ import com.bitdubai.fermat_cbp_api.layer.stock_transactions.crypto_money_destock
 import com.bitdubai.fermat_cbp_api.layer.stock_transactions.crypto_money_destock.interfaces.CryptoMoneyDestockManager;
 import com.bitdubai.fermat_cbp_api.layer.stock_transactions.crypto_money_restock.exceptions.CantCreateCryptoMoneyRestockException;
 import com.bitdubai.fermat_cbp_api.layer.stock_transactions.crypto_money_restock.interfaces.CryptoMoneyRestockManager;
+import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantClearCryptoBrokerWalletSettingException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetAvailableBalanceCryptoBrokerWalletException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetCryptoBrokerMarketRateException;
 import com.bitdubai.fermat_cbp_api.layer.wallet.crypto_broker.exceptions.CantGetCryptoBrokerQuoteException;
@@ -495,6 +497,11 @@ public class CryptoBrokerWalletModuleCryptoBrokerWalletManager implements Crypto
     }
 
     @Override
+    public void clearAssociatedIdentities(String brokerWalletPublicKey) throws CantClearBrokerIdentityWalletRelationshipException {
+        cryptoBrokerActorManager.clearBrokerIdentityWalletRelationship(brokerWalletPublicKey);
+    }
+
+    @Override
     public CustomerBrokerNegotiationInformation cancelNegotiation(CustomerBrokerNegotiationInformation negotiation, String reason) throws CouldNotCancelNegotiationException, CantCancelNegotiationException {
         CustomerBrokerSaleNegotiationImpl customerBrokerSaleNegotiation = new CustomerBrokerSaleNegotiationImpl(
                 negotiation.getNegotiationId(),
@@ -796,11 +803,27 @@ public class CryptoBrokerWalletModuleCryptoBrokerWalletManager implements Crypto
     }
 
     @Override
+    public void clearWalletSetting(String publicKeyWalletCryptoBrokerInstall) throws CantClearCryptoBrokerWalletSettingException, CryptoBrokerWalletNotFoundException, CantGetCryptoBrokerWalletSettingException {
+        //TODO: Quitar este hardcore luego que se implemente la instalacion de la wallet
+        publicKeyWalletCryptoBrokerInstall = "walletPublicKeyTest";
+        cryptoBrokerWalletManager.loadCryptoBrokerWallet(publicKeyWalletCryptoBrokerInstall).getCryptoWalletSetting().clearCryptoBrokerWalletSpreadSetting();
+    }
+
+    @Override
     public void saveWalletSettingAssociated(CryptoBrokerWalletAssociatedSetting cryptoBrokerWalletAssociatedSetting, String publicKeyWalletCryptoBrokerInstall) throws CantGetCryptoBrokerWalletSettingException, CryptoBrokerWalletNotFoundException, CantSaveCryptoBrokerWalletSettingException {
         //TODO: Quitar este hardcore luego que se implemente la instalacion de la wallet
         publicKeyWalletCryptoBrokerInstall = "walletPublicKeyTest";
         cryptoBrokerWalletManager.loadCryptoBrokerWallet(publicKeyWalletCryptoBrokerInstall).getCryptoWalletSetting().saveCryptoBrokerWalletAssociatedSetting(cryptoBrokerWalletAssociatedSetting);
     }
+
+    @Override
+    public void clearAssociatedWalletSettings(String publicKeyWalletCryptoBrokerInstall) throws CryptoBrokerWalletNotFoundException, CantGetCryptoBrokerWalletSettingException, CantClearCryptoBrokerWalletSettingException {
+        //TODO: Quitar este hardcode luego que se implemente la instalacion de la wallet
+        publicKeyWalletCryptoBrokerInstall = "walletPublicKeyTest";
+        cryptoBrokerWalletManager.loadCryptoBrokerWallet(publicKeyWalletCryptoBrokerInstall).getCryptoWalletSetting().clearCryptoBrokerWalletAssociatedSetting();
+    }
+
+
 
     @Override
     public boolean isWalletConfigured(String publicKeyWalletCryptoBrokerInstall) throws CryptoBrokerWalletNotFoundException, CantGetCryptoBrokerWalletSettingException {
@@ -1256,6 +1279,22 @@ public class CryptoBrokerWalletModuleCryptoBrokerWalletManager implements Crypto
         walletPublicKey = "walletPublicKeyTest";
         cryptoBrokerWalletManager.loadCryptoBrokerWallet(walletPublicKey).getCryptoWalletSetting().saveCryptoBrokerWalletProviderSetting(cryptoBrokerWalletProviderSetting);
     }
+
+    /**
+     * This method clears the instance CryptoBrokerWalletProviderSetting
+     *
+     * @return
+     *
+     * @throws CantSaveCryptoBrokerWalletSettingException
+     */
+    @Override
+    public void clearCryptoBrokerWalletProviderSetting(String walletPublicKey) throws CantClearCryptoBrokerWalletSettingException, CryptoBrokerWalletNotFoundException, CantGetCryptoBrokerWalletSettingException {
+        //TODO: Quitar este hardcore luego que se implemente la instalacion de la wallet
+        walletPublicKey = "walletPublicKeyTest";
+        cryptoBrokerWalletManager.loadCryptoBrokerWallet(walletPublicKey).getCryptoWalletSetting().clearCryptoBrokerWalletProviderSetting();
+    }
+
+
 
     /**
      * @param bankAccount


### PR DESCRIPTION
Broker Wallet Wizard fragments now _clear_ the settings they save on onCreate(), so that they can safely write their settings when saveSettingsAndGoToNextStep() is called
