### PR TITLE
Remove redundant references in CBP build.gradle

### DIFF
--- a/ART/android/sub_app/fermat-art-android-sub-app-artist-community-bitdubai/build.gradle
+++ b/ART/android/sub_app/fermat-art-android-sub-app-artist-community-bitdubai/build.gradle
@@ -62,9 +62,9 @@ android {
 }
 dependencies {
     // Fermat
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-art-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])
     // Android

--- a/ART/android/sub_app/fermat-art-android-sub-app-artist-identity-bitdubai/build.gradle
+++ b/ART/android/sub_app/fermat-art-android-sub-app-artist-identity-bitdubai/build.gradle
@@ -62,9 +62,9 @@ android {
 }
 dependencies {
     // Fermat
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-art-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])
     // Android

--- a/ART/android/sub_app/fermat-art-android-sub-app-fan-community-bitdubai/build.gradle
+++ b/ART/android/sub_app/fermat-art-android-sub-app-fan-community-bitdubai/build.gradle
@@ -63,9 +63,9 @@ android {
 }
 dependencies {
     // Fermat
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-art-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])
     // Android

--- a/ART/android/sub_app/fermat-art-android-sub-app-fan-identity-bitdubai/build.gradle
+++ b/ART/android/sub_app/fermat-art-android-sub-app-fan-identity-bitdubai/build.gradle
@@ -64,9 +64,9 @@ android {
 }
 dependencies {
     // Fermat
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-art-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])
     // Android

--- a/ART/android/sub_app/fermat-art-android-sub-app-music-player-bitdubai/build.gradle
+++ b/ART/android/sub_app/fermat-art-android-sub-app-music-player-bitdubai/build.gradle
@@ -62,9 +62,9 @@ android {
 }
 dependencies {
     // Fermat
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-art-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])
     // Android

--- a/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-broker-bitdubai/build.gradle
+++ b/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-broker-bitdubai/build.gradle
@@ -62,8 +62,8 @@ repositories {
 
 dependencies {
     // Fermat
-    compile project(':fermat-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-cbp-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])

--- a/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-customer-bitdubai/build.gradle
+++ b/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-customer-bitdubai/build.gradle
@@ -64,8 +64,8 @@ repositories {
 
 dependencies {
     // Fermat
-    compile project(':fermat-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-cbp-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])

--- a/CBP/android/sub_app/fermat-cbp-android-sub-app-crypto-broker-community-bitdubai/build.gradle
+++ b/CBP/android/sub_app/fermat-cbp-android-sub-app-crypto-broker-community-bitdubai/build.gradle
@@ -60,8 +60,9 @@ android {
 }
 dependencies {
     /** module dependencies  **/
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-android-api')
+    compile project(':fermat-cbp-api')
     /* android dependencies */
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:support-v4:23.1.1'
@@ -72,7 +73,6 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
     compile 'com.squareup.picasso:picasso:2.3.2'
     compile 'com.android.support:appcompat-v7:23.1.1'
-    compile project(':fermat-cbp-api')
 }
 // Configuracion de JaCoCo
 def jacocoHtmlReport = ""

--- a/CBP/android/sub_app/fermat-cbp-android-sub-app-crypto-broker-identity-bitdubai/build.gradle
+++ b/CBP/android/sub_app/fermat-cbp-android-sub-app-crypto-broker-identity-bitdubai/build.gradle
@@ -63,7 +63,7 @@ android {
 }
 dependencies {
     // Fermat
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])

--- a/CBP/android/sub_app/fermat-cbp-android-sub-app-crypto-customer-community-bitdubai/build.gradle
+++ b/CBP/android/sub_app/fermat-cbp-android-sub-app-crypto-customer-community-bitdubai/build.gradle
@@ -61,7 +61,7 @@ android {
 }
 dependencies {
     // Fermat
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])

--- a/CBP/android/sub_app/fermat-cbp-android-sub-app-crypto-customer-identity-bitdubai/build.gradle
+++ b/CBP/android/sub_app/fermat-cbp-android-sub-app-crypto-customer-identity-bitdubai/build.gradle
@@ -61,7 +61,7 @@ android {
 }
 dependencies {
     // Fermat
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])

--- a/CBP/library/api/fermat-cbp-api/build.gradle
+++ b/CBP/library/api/fermat-cbp-api/build.gradle
@@ -20,12 +20,13 @@ configurations {
 
 dependencies {
     compile project(':fermat-api')
-    compile project(':fermat-wpd-api')
-    compile project(':fermat-bnk-api')
-    compile project(':fermat-csh-api')
-    compile project(':fermat-cer-api')
     compile project(':fermat-bch-api')
+    compile project(':fermat-bnk-api')
+    compile project(':fermat-ccp-api')
+    compile project(':fermat-cer-api')
+    compile project(':fermat-csh-api')
     compile project(':fermat-p2p-api')
+    compile project(':fermat-wpd-api')
 
     testCompile 'junit:junit:4.11'
     testCompile 'org.easytesting:fest-assert-core:2.0M10'

--- a/CBP/plugin/actor/fermat-cbp-plugin-actor-crypto-broker-bitdubai/build.gradle
+++ b/CBP/plugin/actor/fermat-cbp-plugin-actor-crypto-broker-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/actor/fermat-cbp-plugin-actor-crypto-customer-bitdubai/build.gradle
+++ b/CBP/plugin/actor/fermat-cbp-plugin-actor-crypto-customer-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/actor_connection/fermat-cbp-plugin-actor-connection-crypto-broker-bitdubai/build.gradle
+++ b/CBP/plugin/actor_connection/fermat-cbp-plugin-actor-connection-crypto-broker-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/actor_connection/fermat-cbp-plugin-actor-connection-crypto-customer-bitdubai/build.gradle
+++ b/CBP/plugin/actor_connection/fermat-cbp-plugin-actor-connection-crypto-customer-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/actor_network_service/fermat-cbp-plugin-actor-network-service-crypto-broker-bitdubai/build.gradle
+++ b/CBP/plugin/actor_network_service/fermat-cbp-plugin-actor-network-service-crypto-broker-bitdubai/build.gradle
@@ -13,10 +13,10 @@ repositories {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-p2p-api')
-    compile project(':fermat-pip-api')
+    // project(':fermat-p2p-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/actor_network_service/fermat-cbp-plugin-actor-network-service-crypto-customer-bitdubai/build.gradle
+++ b/CBP/plugin/actor_network_service/fermat-cbp-plugin-actor-network-service-crypto-customer-bitdubai/build.gradle
@@ -13,10 +13,10 @@ repositories {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-p2p-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-p2p-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-broker-ack-offline-payment-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-broker-ack-offline-payment-bitdubai/build.gradle
@@ -19,11 +19,11 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
-    compile project(':fermat-bnk-api')
-    compile project(':fermat-csh-api')
+    //compile project(':fermat-pip-api')
+    //compile project(':fermat-bnk-api')
+    //compile project(':fermat-csh-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-broker-ack-online-payment-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-broker-ack-online-payment-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-broker-submit-offline-merchandise-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-broker-submit-offline-merchandise-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-broker-submit-online-merchandise-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-broker-submit-online-merchandise-bitdubai/build.gradle
@@ -19,10 +19,10 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
-    compile project(':fermat-ccp-api')
+    //compile project(':fermat-pip-api')
+    //compile project(':fermat-ccp-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-close-contract-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-close-contract-bitdubai/build.gradle
@@ -6,8 +6,8 @@ version = '1.0'
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':fermat-pip-api')
-    compile project(':fermat-api')
+    //compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
     //compile project(':fermat-p2p-api')
 

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-ack-offline-merchandise-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-ack-offline-merchandise-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-ack-online-merchandise-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-ack-online-merchandise-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-offline-payment-bitdubai/build.gradle
@@ -19,11 +19,11 @@ configurations {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':fermat-pip-api')
+    //compile fileTree(dir: 'libs', include: ['*.jar'])
+    //compile project(':fermat-pip-api')
     compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-ccp-api')
+    //compile project(':fermat-ccp-api')
     testCompile "junit:junit:4.11"
     testCompile 'org.mockito:mockito-all:2.0.2-beta'
 

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-customer-online-payment-bitdubai/build.gradle
@@ -9,11 +9,11 @@ targetCompatibility = 1.7
 version = '1.0'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':fermat-pip-api')
-    compile project(':fermat-api')
+    //compile fileTree(dir: 'libs', include: ['*.jar'])
+    //compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-ccp-api')
+    //compile project(':fermat-ccp-api')
     testCompile "junit:junit:4.11"
     testCompile 'org.mockito:mockito-all:2.0.2-beta'
 

--- a/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-open-contract-bitdubai/build.gradle
+++ b/CBP/plugin/business_transaction/fermat-cbp-plugin-business-transaction-open-contract-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':fermat-pip-api')
-    compile project(':fermat-api')
+    //compile fileTree(dir: 'libs', include: ['*.jar'])
+    //compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
     //compile project(':fermat-p2p-api')
 

--- a/CBP/plugin/contract/fermat-cbp-plugin-contract-customer-broker-purchase-bitdubai/build.gradle
+++ b/CBP/plugin/contract/fermat-cbp-plugin-contract-customer-broker-purchase-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/contract/fermat-cbp-plugin-contract-customer-broker-sale-bitdubai/build.gradle
+++ b/CBP/plugin/contract/fermat-cbp-plugin-contract-customer-broker-sale-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/identity/fermat-cbp-plugin-identity-crypto-broker-bitdubai/build.gradle
+++ b/CBP/plugin/identity/fermat-cbp-plugin-identity-crypto-broker-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/identity/fermat-cbp-plugin-identity-crypto-customer-bitdubai/build.gradle
+++ b/CBP/plugin/identity/fermat-cbp-plugin-identity-crypto-customer-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/middleware/fermat-cbp-plugin-middleware-matching-engine-bitdubai/build.gradle
+++ b/CBP/plugin/middleware/fermat-cbp-plugin-middleware-matching-engine-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/negotiation/fermat-cbp-plugin-negotiation-customer-broker-purchase-bitdubai/build.gradle
+++ b/CBP/plugin/negotiation/fermat-cbp-plugin-negotiation-customer-broker-purchase-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/negotiation/fermat-cbp-plugin-negotiation-customer-broker-sale-bitdubai/build.gradle
+++ b/CBP/plugin/negotiation/fermat-cbp-plugin-negotiation-customer-broker-sale-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/negotiation_transaction/fermat-cbp-plugin-negotiation-transaction-customer-broker-close-bitdubai/build.gradle
+++ b/CBP/plugin/negotiation_transaction/fermat-cbp-plugin-negotiation-transaction-customer-broker-close-bitdubai/build.gradle
@@ -19,10 +19,10 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
-    compile project(':fermat-ccp-api')
+    //compile project(':fermat-pip-api')
+    //compile project(':fermat-ccp-api')
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'
     testCompile group: 'com.googlecode.catch-exception', name: 'catch-exception', version: '1.2.0'

--- a/CBP/plugin/negotiation_transaction/fermat-cbp-plugin-negotiation-transaction-customer-broker-new-bitdubai/build.gradle
+++ b/CBP/plugin/negotiation_transaction/fermat-cbp-plugin-negotiation-transaction-customer-broker-new-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/negotiation_transaction/fermat-cbp-plugin-negotiation-transaction-customer-broker-update-bitdubai/build.gradle
+++ b/CBP/plugin/negotiation_transaction/fermat-cbp-plugin-negotiation-transaction-customer-broker-update-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/network_service/fermat-cbp-plugin-network-service-negotiation-transmission-bitdubai/build.gradle
+++ b/CBP/plugin/network_service/fermat-cbp-plugin-network-service-negotiation-transmission-bitdubai/build.gradle
@@ -19,10 +19,10 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
-    compile project(':fermat-p2p-api')
+    //compile project(':fermat-pip-api')
+    //compile project(':fermat-p2p-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/network_service/fermat-cbp-plugin-network-service-transaction-transmission-bitdubai/build.gradle
+++ b/CBP/plugin/network_service/fermat-cbp-plugin-network-service-transaction-transmission-bitdubai/build.gradle
@@ -19,11 +19,11 @@ configurations {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':fermat-api')
-    compile project(':fermat-pip-api')
+    //compile fileTree(dir: 'libs', include: ['*.jar'])
+    //compile project(':fermat-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-p2p-api')
+    //compile project(':fermat-p2p-api')
     //compile 'junit:junit:4.12'
     //compile 'org.mockito:mockito-core:1.9.5'
     testCompile 'junit:junit:4.11'

--- a/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-bank-money-destock-bitdubai/build.gradle
+++ b/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-bank-money-destock-bitdubai/build.gradle
@@ -19,10 +19,10 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-bnk-api')
+    //compile project(':fermat-bnk-api')
 
 
     testCompile group: 'junit', name: 'junit', version: '4.11'

--- a/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-bank-money-restock-bitdubai/build.gradle
+++ b/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-bank-money-restock-bitdubai/build.gradle
@@ -19,10 +19,10 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-bnk-api')
+    //compile project(':fermat-bnk-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-cash-money-destock-bitdubai/build.gradle
+++ b/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-cash-money-destock-bitdubai/build.gradle
@@ -19,10 +19,10 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-csh-api')
+    //compile project(':fermat-csh-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-cash-money-restock-bitdubai/build.gradle
+++ b/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-cash-money-restock-bitdubai/build.gradle
@@ -19,10 +19,10 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-csh-api')
+    //compile project(':fermat-csh-api')
 
 
     testCompile group: 'junit', name: 'junit', version: '4.11'

--- a/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-crypto-money-destock-bitdubai/build.gradle
+++ b/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-crypto-money-destock-bitdubai/build.gradle
@@ -19,10 +19,10 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-ccp-api')
+    //compile project(':fermat-ccp-api')
     testCompile 'junit:junit:4.11'
     testCompile 'org.easytesting:fest-assert-core:2.0M10'
     testCompile 'com.googlecode.catch-exception:catch-exception:1.2.0'

--- a/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-crypto-money-restock-bitdubai/build.gradle
+++ b/CBP/plugin/stock_transactions/fermat-cbp-plugin-stock-transactions-crypto-money-restock-bitdubai/build.gradle
@@ -19,10 +19,10 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-ccp-api')
+    //compile project(':fermat-ccp-api')
 
 
     testCompile group: 'junit', name: 'junit', version: '4.11'

--- a/CBP/plugin/sub_app_module/fermat-cbp-plugin-sub-app-module-crypto-broker-community-bitdubai/build.gradle
+++ b/CBP/plugin/sub_app_module/fermat-cbp-plugin-sub-app-module-crypto-broker-community-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/sub_app_module/fermat-cbp-plugin-sub-app-module-crypto-broker-identity-bitdubai/build.gradle
+++ b/CBP/plugin/sub_app_module/fermat-cbp-plugin-sub-app-module-crypto-broker-identity-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/sub_app_module/fermat-cbp-plugin-sub-app-module-crypto-customer-community-bitdubai/build.gradle
+++ b/CBP/plugin/sub_app_module/fermat-cbp-plugin-sub-app-module-crypto-customer-community-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/sub_app_module/fermat-cbp-plugin-sub-app-module-crypto-customer-identity-bitdubai/build.gradle
+++ b/CBP/plugin/sub_app_module/fermat-cbp-plugin-sub-app-module-crypto-customer-identity-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/user_level_business_transaction/fermat-cbp-plugin-user-level-business-transaction-customer-broker-purchase-bitdubai/build.gradle
+++ b/CBP/plugin/user_level_business_transaction/fermat-cbp-plugin-user-level-business-transaction-customer-broker-purchase-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/user_level_business_transaction/fermat-cbp-plugin-user-level-business-transaction-customer-broker-sale-bitdubai/build.gradle
+++ b/CBP/plugin/user_level_business_transaction/fermat-cbp-plugin-user-level-business-transaction-customer-broker-sale-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/wallet/fermat-cbp-plugin-wallet-crypto-broker-bitdubai/build.gradle
+++ b/CBP/plugin/wallet/fermat-cbp-plugin-wallet-crypto-broker-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/wallet_module/fermat-cbp-plugin-wallet-module-crypto-broker-bitdubai/build.gradle
+++ b/CBP/plugin/wallet_module/fermat-cbp-plugin-wallet-module-crypto-broker-bitdubai/build.gradle
@@ -19,11 +19,11 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
-    compile project(':fermat-cer-api')
-    compile project(':fermat-ccp-api')
+    //compile project(':fermat-pip-api')
+    //compile project(':fermat-cer-api')
+    //compile project(':fermat-ccp-api')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.easytesting', name: 'fest-assert-core', version: '2.0M10'

--- a/CBP/plugin/wallet_module/fermat-cbp-plugin-wallet-module-crypto-customer-bitdubai/build.gradle
+++ b/CBP/plugin/wallet_module/fermat-cbp-plugin-wallet-module-crypto-customer-bitdubai/build.gradle
@@ -19,9 +19,9 @@ configurations {
 }
 
 dependencies {
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-cbp-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
     testCompile 'junit:junit:4.11'
     testCompile 'org.easytesting:fest-assert-core:2.0M10'
     testCompile 'com.googlecode.catch-exception:catch-exception:1.2.0'

--- a/TKY/android/sub_app/fermat-tky-android-sub-app-artist-identity-bitdubai/build.gradle
+++ b/TKY/android/sub_app/fermat-tky-android-sub-app-artist-identity-bitdubai/build.gradle
@@ -63,9 +63,9 @@ android {
 }
 dependencies {
     // Fermat
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-tky-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])
     // Android

--- a/TKY/android/sub_app/fermat-tky-android-sub-app-fan-identity-bitdubai/build.gradle
+++ b/TKY/android/sub_app/fermat-tky-android-sub-app-fan-identity-bitdubai/build.gradle
@@ -62,9 +62,9 @@ android {
 }
 dependencies {
     // Fermat
-    compile project(':fermat-api')
+    //compile project(':fermat-api')
     compile project(':fermat-tky-api')
-    compile project(':fermat-pip-api')
+    //compile project(':fermat-pip-api')
     compile project(':fermat-android-api')
     compile fileTree(dir: 'libs', include: ['*.jar'])
     // Android

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@
  */
 rootProject.name = 'Fermat'
 
-apply from: 'ART/settings.gradle'
+//apply from: 'ART/settings.gradle'
 apply from: 'BCH/settings.gradle'
 apply from: 'BNK/settings.gradle'
 apply from: 'CBP/settings.gradle'
@@ -16,7 +16,7 @@ apply from: 'DAP/settings.gradle'
 apply from: 'OSA/settings.gradle'
 apply from: 'P2P/settings.gradle'
 apply from: 'PIP/settings.gradle'
-apply from: 'TKY/settings.gradle'
+//apply from: 'TKY/settings.gradle'
 apply from: 'WPD/settings.gradle'
 apply from: 'android_toolbox/settings.gradle'
 


### PR DESCRIPTION
**Includes:**
- Remove redundant references in all CBP build.gradle.
