### PR TITLE
Fix: android cash wallet and CBP broker identity

### DIFF
--- a/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-broker-bitdubai/src/main/res/layout/cbw_settings_fee_management.xml
+++ b/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-broker-bitdubai/src/main/res/layout/cbw_settings_fee_management.xml
@@ -52,7 +52,7 @@
             <RadioButton
                 android:id="@+id/cbw_radio_button_slow"
                 style="@style/cbw_radioButton"
-                android:layout_width="wrap_content"
+                android:layout_width="80dp"
                 android:layout_height="match_parent"
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"
@@ -64,7 +64,7 @@
             <RadioButton
                 android:id="@+id/cbw_radio_button_normal"
                 style="@style/cbw_radioButton"
-                android:layout_width="wrap_content"
+                android:layout_width="100dp"
                 android:layout_height="match_parent"
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"
@@ -77,7 +77,7 @@
             <RadioButton
                 android:id="@+id/cbw_radio_button_fast"
                 style="@style/cbw_radioButton"
-                android:layout_width="wrap_content"
+                android:layout_width="80dp"
                 android:layout_height="match_parent"
                 android:text="  Fast"
                 android:textAllCaps="true"

--- a/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-customer-bitdubai/src/main/res/layout/ccw_settings_fee_management.xml
+++ b/CBP/android/reference_wallet/fermat-cbp-android-reference-wallet-crypto-customer-bitdubai/src/main/res/layout/ccw_settings_fee_management.xml
@@ -52,7 +52,7 @@
             <RadioButton
                 android:id="@+id/ccw_radio_button_slow"
                 style="@style/ccw_radioButton"
-                android:layout_width="wrap_content"
+                android:layout_width="80dp"
                 android:layout_height="match_parent"
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"
@@ -64,7 +64,7 @@
             <RadioButton
                 android:id="@+id/ccw_radio_button_normal"
                 style="@style/ccw_radioButton"
-                android:layout_width="wrap_content"
+                android:layout_width="100dp"
                 android:layout_height="match_parent"
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"
@@ -77,7 +77,7 @@
             <RadioButton
                 android:id="@+id/ccw_radio_button_fast"
                 style="@style/ccw_radioButton"
-                android:layout_width="wrap_content"
+                android:layout_width="80dp"
                 android:layout_height="match_parent"
                 android:text="  Fast"
                 android:textAllCaps="true"

--- a/CBP/android/sub_app/fermat-cbp-android-sub-app-crypto-broker-identity-bitdubai/src/main/java/com/bitdubai/sub_app/crypto_broker_identity/util/EditIdentityWorker.java
+++ b/CBP/android/sub_app/fermat-cbp-android-sub-app-crypto-broker-identity-bitdubai/src/main/java/com/bitdubai/sub_app/crypto_broker_identity/util/EditIdentityWorker.java
@@ -43,7 +43,7 @@ public class EditIdentityWorker extends FermatWorker {
 
                 System.out.println("VLZ: Publicando");
 
-                moduleManager.publishIdentity(identity.getPublicKey());
+                moduleManager.unHideIdentity(identity.getPublicKey());
             }else {
 
                 System.out.println("VLZ: Ocultando");

--- a/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/identity/crypto_broker/exceptions/CantUnHideIdentityException.java
+++ b/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/identity/crypto_broker/exceptions/CantUnHideIdentityException.java
@@ -1,0 +1,19 @@
+package com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions;
+
+import com.bitdubai.fermat_api.FermatException;
+
+/**
+ * Created by Miguel Payarez (miguel_payarez@hotmail.com) on 7/11/16.
+ */
+public class CantUnHideIdentityException extends FermatException {
+
+    private static final String DEFAULT_MESSAGE = "CANT UNHIDE IDENTITY EXCEPTION";
+
+    public CantUnHideIdentityException(String message, Exception cause, String context, String possibleReason) {
+        super(message, cause, context, possibleReason);
+    }
+
+    public CantUnHideIdentityException(Exception cause, String context, String possibleReason) {
+        this(DEFAULT_MESSAGE, cause, context, possibleReason);
+    }
+}

--- a/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/identity/crypto_broker/interfaces/CryptoBrokerIdentityManager.java
+++ b/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/identity/crypto_broker/interfaces/CryptoBrokerIdentityManager.java
@@ -7,6 +7,7 @@ import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantG
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantHideIdentityException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantListCryptoBrokerIdentitiesException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantPublishIdentityException;
+import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantUnHideIdentityException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantUpdateBrokerIdentityException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CryptoBrokerIdentityAlreadyExistsException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.IdentityNotFoundException;
@@ -65,6 +66,17 @@ public interface CryptoBrokerIdentityManager extends FermatManager {
      * @throws IdentityNotFoundException    if we can't find an identity with the given public key.
      */
     void publishIdentity(String publicKey) throws CantPublishIdentityException, IdentityNotFoundException;
+
+
+    /**
+     * The method <code>UnHideIdentity</code> is used to publish a Broker identity
+     *
+     * @param publicKey the public key of the crypto Broker to publish
+     *
+     * @throws CantUnHideIdentityException if something goes wrong.
+     * @throws IdentityNotFoundException    if we can't find an identity with the given public key.
+     */
+    void unHideIdentity(String publicKey) throws  CantUnHideIdentityException, IdentityNotFoundException ;
 
     /**
      * The method <code>publishIdentity</code> is used to publish a Broker identity

--- a/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/sub_app_module/crypto_broker_identity/exceptions/CantUnHideCryptoBrokerException.java
+++ b/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/sub_app_module/crypto_broker_identity/exceptions/CantUnHideCryptoBrokerException.java
@@ -1,0 +1,20 @@
+package com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions;
+
+import com.bitdubai.fermat_api.FermatException;
+
+/**
+ * Created by Miguel Payarez (miguel_payarez@hotmail.com) on 7/11/16.
+ */
+public class CantUnHideCryptoBrokerException extends FermatException {
+
+    private static final String DEFAULT_MESSAGE = "CAN'T UNHIDE CRYPTO BROKER IDENTITY EXCEPTION";
+
+    public CantUnHideCryptoBrokerException(String message, Exception cause, String context, String possibleReason) {
+        super(message, cause, context, possibleReason);
+    }
+
+    public CantUnHideCryptoBrokerException(Exception cause, String context, String possibleReason) {
+        super(DEFAULT_MESSAGE, cause, context, possibleReason);
+    }
+}
+

--- a/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/sub_app_module/crypto_broker_identity/interfaces/CryptoBrokerIdentityModuleManager.java
+++ b/CBP/library/api/fermat-cbp-api/src/main/java/com/bitdubai/fermat_cbp_api/layer/sub_app_module/crypto_broker_identity/interfaces/CryptoBrokerIdentityModuleManager.java
@@ -12,6 +12,7 @@ import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.e
 import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CantHideCryptoBrokerException;
 import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CantListCryptoBrokersException;
 import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CantPublishCryptoBrokerException;
+import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CantUnHideCryptoBrokerException;
 import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CryptoBrokerNotFoundException;
 
 import java.io.Serializable;
@@ -49,6 +50,14 @@ public interface CryptoBrokerIdentityModuleManager extends ModuleManager<Identit
      * @throws CantPublishCryptoBrokerException if something goes wrong.
      */
     void publishIdentity(String publicKey) throws CantPublishCryptoBrokerException, CryptoBrokerNotFoundException;
+
+    /**
+     * The method <code>unhideidentity</code> is used to publish a Broker identity
+     *
+     * @param publicKey the public key of the crypto Broker to publish
+     * @throws CantUnHideCryptoBrokerException if something goes wrong.
+     */
+    void unHideIdentity (String publicKey) throws CantUnHideCryptoBrokerException, CryptoBrokerNotFoundException;
 
     /**
      * The method <code>publishIdentity</code> is used to publish a Broker identity

--- a/CBP/plugin/identity/fermat-cbp-plugin-identity-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/identity/crypto_broker/developer/bitdubai/version_1/CryptoBrokerIdentityPluginRoot.java
+++ b/CBP/plugin/identity/fermat-cbp-plugin-identity-crypto-broker-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/identity/crypto_broker/developer/bitdubai/version_1/CryptoBrokerIdentityPluginRoot.java
@@ -42,11 +42,13 @@ import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantG
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantHideIdentityException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantListCryptoBrokerIdentitiesException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantPublishIdentityException;
+import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantUnHideIdentityException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantUpdateBrokerIdentityException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CryptoBrokerIdentityAlreadyExistsException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.IdentityNotFoundException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.interfaces.CryptoBrokerIdentity;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.interfaces.CryptoBrokerIdentityManager;
+import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CantUnHideCryptoBrokerException;
 import com.bitdubai.fermat_cbp_plugin.layer.identity.crypto_broker.developer.bitdubai.version_1.database.CryptoBrokerIdentityDatabaseDao;
 import com.bitdubai.fermat_cbp_plugin.layer.identity.crypto_broker.developer.bitdubai.version_1.database.CryptoBrokerIdentityDeveloperDatabaseFactory;
 import com.bitdubai.fermat_cbp_plugin.layer.identity.crypto_broker.developer.bitdubai.version_1.exceptions.CantChangeExposureLevelException;
@@ -229,6 +231,23 @@ public class CryptoBrokerIdentityPluginRoot extends AbstractPlugin implements Cr
             reportError(UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
             throw new CantPublishIdentityException(e, "", "Unhandled Exception.");
         }
+    }
+
+    @Override
+    public void unHideIdentity(String publicKey) throws CantUnHideIdentityException, IdentityNotFoundException {
+        try {
+            cryptoBrokerIdentityDatabaseDao.changeExposureLevel(publicKey, ExposureLevel.PUBLISH);
+        } catch (final CantChangeExposureLevelException e) {
+            reportError(UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+            throw new CantUnHideIdentityException(e, "", "There was a problem trying to change the exposure level.");
+        } catch (final IdentityNotFoundException e) {
+            reportError(UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+            throw e;
+        } catch (final Exception e) {
+            reportError(UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+            throw new CantUnHideIdentityException(e, "", "Unhandled Exception.");
+        }
+
     }
 
     @Override

--- a/CBP/plugin/sub_app_module/fermat-cbp-plugin-sub-app-module-crypto-broker-identity-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/sub_app_module/crypto_broker_identity/developer/bitdubai/version_1/structure/CryptoBrokerIdentityModuleManagerImpl.java
+++ b/CBP/plugin/sub_app_module/fermat-cbp-plugin-sub-app-module-crypto-broker-identity-bitdubai/src/main/java/com/bitdubai/fermat_cbp_plugin/layer/sub_app_module/crypto_broker_identity/developer/bitdubai/version_1/structure/CryptoBrokerIdentityModuleManagerImpl.java
@@ -14,6 +14,7 @@ import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantC
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantHideIdentityException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantListCryptoBrokerIdentitiesException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantPublishIdentityException;
+import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantUnHideIdentityException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CantUpdateBrokerIdentityException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.CryptoBrokerIdentityAlreadyExistsException;
 import com.bitdubai.fermat_cbp_api.layer.identity.crypto_broker.exceptions.IdentityNotFoundException;
@@ -24,6 +25,7 @@ import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.e
 import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CantHideCryptoBrokerException;
 import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CantListCryptoBrokersException;
 import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CantPublishCryptoBrokerException;
+import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CantUnHideCryptoBrokerException;
 import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.exceptions.CryptoBrokerNotFoundException;
 import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.interfaces.CryptoBrokerIdentityInformation;
 import com.bitdubai.fermat_cbp_api.layer.sub_app_module.crypto_broker_identity.interfaces.CryptoBrokerIdentityModuleManager;
@@ -75,6 +77,23 @@ public class CryptoBrokerIdentityModuleManagerImpl
     @Override
     public void updateCryptoBrokerIdentity(CryptoBrokerIdentityInformation cryptoBrokerIdentity)  throws CantUpdateBrokerIdentityException {
         this.identityManager.updateCryptoBrokerIdentity(cryptoBrokerIdentity.getAlias(), cryptoBrokerIdentity.getPublicKey(), cryptoBrokerIdentity.getProfileImage(), cryptoBrokerIdentity.getAccuracy(), cryptoBrokerIdentity.getFrequency());
+    }
+
+    @Override
+    public void unHideIdentity(String publicKey) throws CantUnHideCryptoBrokerException, CryptoBrokerNotFoundException {
+
+        try {
+            this.identityManager.unHideIdentity(publicKey);
+        } catch (CantUnHideIdentityException e) {
+            pluginRoot.reportError(UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+            throw new CantUnHideCryptoBrokerException(e, "", "Problem UNHIDE the identity.");
+        } catch (IdentityNotFoundException e) {
+            pluginRoot.reportError(UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+            throw new CantUnHideCryptoBrokerException(e, "", "Cannot find the identity.");
+        } catch (Exception e) {
+            pluginRoot.reportError(UnexpectedPluginExceptionSeverity.DISABLES_SOME_FUNCTIONALITY_WITHIN_THIS_PLUGIN, e);
+            throw new CantUnHideCryptoBrokerException(e, "", "Unhandled Exception.");
+        }
     }
 
     @Override

--- a/CSH/android/reference_wallet/fermat-csh-android-reference-wallet-cash-money-bitdubai/src/main/res/layout/csh_transaction_list_item.xml
+++ b/CSH/android/reference_wallet/fermat-csh-android-reference-wallet-cash-money-bitdubai/src/main/res/layout/csh_transaction_list_item.xml
@@ -4,9 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/relativeLayout_deposit"
     android:layout_width="wrap_content"
-    android:layout_height="54dp"
+    android:layout_height="58dp"
     android:background="@color/csh_transaction_item_background"
-    android:paddingBottom="4dp"
+    android:paddingBottom="2dp"
     android:paddingEnd="@dimen/csh_activity_horizontal_margin"
     android:paddingLeft="@dimen/csh_activity_horizontal_margin"
     android:paddingRight="@dimen/csh_activity_horizontal_margin"
@@ -44,7 +44,7 @@
         android:layout_alignParentBottom="true"
         android:layout_toLeftOf="@+id/csh_list_item_transaction_type"
         android:layout_marginRight="10dp"
-        android:layout_marginBottom="8dp"
+        android:layout_marginBottom="10dp"
         android:ellipsize="end"
         android:layout_gravity="left"
         android:singleLine="true"
@@ -59,7 +59,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_alignParentBottom="true"
-        android:layout_marginBottom="7dp"
+        android:layout_marginBottom="9dp"
         android:singleLine="true"
         android:textColor="@color/csh_transaction_withdrawal_color"
         android:textSize="@dimen/csh_regular_text_size"
@@ -74,6 +74,7 @@
         android:indeterminate="true"
         android:visibility="invisible"
         android:layout_alignParentBottom="true"
-        android:layout_centerHorizontal="true"/>
+        android:layout_centerHorizontal="true"
+         />
 
 </RelativeLayout>

--- a/CSH/android/reference_wallet/fermat-csh-android-reference-wallet-cash-money-bitdubai/src/main/res/values/colors.xml
+++ b/CSH/android/reference_wallet/fermat-csh-android-reference-wallet-cash-money-bitdubai/src/main/res/values/colors.xml
@@ -13,10 +13,10 @@
     <color name="csh_transaction_hold_color_progress_bar">#e08c26</color>
     <color name="csh_transaction_unhold_color">#42f57e</color>
     <color name="csh_transaction_unhold_color_progress_bar">#26e04b</color>
-    <color name="csh_transaction_deposit_color">#42a5f5</color>
-    <color name="csh_transaction_deposit_color_progress_bar">#26A9E0</color>
-    <color name="csh_transaction_withdrawal_color">#ef5350</color>
-    <color name="csh_transaction_withdrawal_color_progress_bar">#E73625</color>
+    <color name="csh_transaction_deposit_color">#424cf5</color>
+    <color name="csh_transaction_deposit_color_progress_bar">#424cf5</color>
+    <color name="csh_transaction_withdrawal_color">#de1814</color>
+    <color name="csh_transaction_withdrawal_color_progress_bar">#de1814</color>
     <color name="csh_transaction_amount_text_color">#000000</color>
     <color name="csh_transaction_memo_text_color">#000000</color>
     <color name="csh_transaction_date_text_color">#000000</color>

--- a/CSH/android/reference_wallet/fermat-csh-android-reference-wallet-cash-money-bitdubai/src/main/res/values/dimens.xml
+++ b/CSH/android/reference_wallet/fermat-csh-android-reference-wallet-cash-money-bitdubai/src/main/res/values/dimens.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="csh_activity_horizontal_margin">16dp</dimen>
+    <dimen name="csh_activity_horizontal_margin">14dp</dimen>
     <dimen name="csh_activity_vertical_margin">8dp</dimen>
 
     <dimen name="csh_titlebar_intertitle_padding">10dp</dimen>


### PR DESCRIPTION
-The increase the separation of transaction type 
and the memo message in the cash wallet. 
-Resolve #676
